### PR TITLE
Fix test for deno v0.34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       - name: clone repo
         uses: actions/checkout@v1.0.0
       - name: install deno
-        uses: denolib/setup-deno@v1.1.0
+        uses: denolib/setup-deno@v1.2.0
       - name: run tests
-        run: deno run --allow-read ./test.ts
+        run: deno test

--- a/mod.ts
+++ b/mod.ts
@@ -9,13 +9,13 @@ export const BYTES: number = 64;
 /** A class representation of the SHA2-512 algorithm. */
 export class SHA512 {
   readonly hashSize: number = BYTES;
-  
+
   private _buffer: Uint8Array = new Uint8Array(128);
-  private _bufferIndex: number;
-  private _count: Uint32Array;
+  private _bufferIndex!: number;
+  private _count!: Uint32Array;
   private _K: Uint32Array;
-  private _H: Uint32Array;
-  private _finalized: boolean;
+  private _H!: Uint32Array;
+  private _finalized!: boolean;
 
   /** Creates a SHA512 instance. */
   constructor() {

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,3 @@
-import { test, runIfMain } from "https://deno.land/std/testing/mod.ts";
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 import { sha512 } from "./mod.ts";
 
@@ -23,9 +22,9 @@ function hex2buf(hex: string): Uint8Array {
   return buf;
 }
 
-const testVectors: TestVector[] = JSON.parse(
+const testVectors: TestVector[] = (JSON.parse(
   new TextDecoder().decode(Deno.readFileSync("./test_vectors.json"))
-).map(
+) as any[]).map(
   ({ msg, msg_bit_len, hash }): TestVector => ({
     msg: hex2buf(msg),
     msg_bit_len,
@@ -34,12 +33,10 @@ const testVectors: TestVector[] = JSON.parse(
 );
 
 testVectors.forEach(({ msg, msg_bit_len, hash }: TestVector) => {
-  test({
+  Deno.test({
     name: `SHA2-512 ${msg_bit_len ? msg_bit_len / 8 : 0}-byte msg`,
     fn(): void {
       assertEquals(sha512(msg), hash);
     }
   });
 });
-
-runIfMain(import.meta, { parallel: true });


### PR DESCRIPTION
Deno v0.34 uses strict mode. This branch fixes issues with the types and updates the tests to use `Deno.test` instead.